### PR TITLE
Alterando método de autorização para classe base

### DIFF
--- a/FactoryMethodDesignPattern/Manager/Processors/Base/ProcessorBase.cs
+++ b/FactoryMethodDesignPattern/Manager/Processors/Base/ProcessorBase.cs
@@ -2,15 +2,37 @@
 
 namespace FactoryMethodDesignPattern.Manager.Processors.Base
 {
+    using Domain;
     using Domain.Base;
+    using Manager.Processors.Interfaces;
 
     public abstract class ProcessorBase<T> where T : TransactionBase
     {
+        public TransactionInfo Authorize(TransactionBase transaction)
+        {
+            var transactionType = ValidateTransactionType(transaction);
+
+            return ProcessAuthorization(transactionType);
+        }
+
         protected T ValidateTransactionType(TransactionBase transaction)
         {
             if (!(transaction is T)) throw new ArgumentException("Invalid Transaction Type");
 
             return (T)transaction;
         }
+
+        protected TransactionInfo ProcessAuthorization(T transaction)
+        {
+            transaction.SetStatusInProgress();
+
+            BusinessSimulation(ref transaction);
+
+            return new TransactionInfo(transaction.TransactionKey,
+                transaction.CreateDate, transaction.Amount,
+                    transaction.TransactionStatusType);
+        }
+
+        protected abstract void BusinessSimulation(ref T crediCardTransaction);
     }
 }

--- a/FactoryMethodDesignPattern/Manager/Processors/CrediCardTransactionProcessor.cs
+++ b/FactoryMethodDesignPattern/Manager/Processors/CrediCardTransactionProcessor.cs
@@ -2,34 +2,15 @@
 {
     using Base;
     using Domain;
-    using Domain.Base;
     using Interfaces;
 
     public class CrediCardTransactionProcessor : ProcessorBase<CreditCardTransaction>, ITransactionProcessor
     {
-        public TransactionInfo Authorize(TransactionBase transaction)
-        {
-            var crediCardTransaction = ValidateTransactionType(transaction);
-
-            return ProcessAuthorization(crediCardTransaction);
-        }
-
-        private static TransactionInfo ProcessAuthorization(CreditCardTransaction crediCardTransaction)
-        {
-            crediCardTransaction.SetStatusInProgress();
-
-            BusinessSimulation(ref crediCardTransaction);
-
-            return new TransactionInfo(crediCardTransaction.TransactionKey,
-                crediCardTransaction.CreateDate, crediCardTransaction.Amount,
-                    crediCardTransaction.TransactionStatusType);
-        }
-
         /// <summary>
         /// Código de simulação de autorização, apenas para fins didádicos
         /// </summary>
         /// <param name="crediCardTransaction">transação de crédito</param>
-        private static void BusinessSimulation(ref CreditCardTransaction crediCardTransaction)
+        protected override void BusinessSimulation(ref CreditCardTransaction crediCardTransaction)
         {
             // Autoriza se o valor estiver entre 10 e 12.000 reais
 

--- a/FactoryMethodDesignPattern/Manager/Processors/DebitTransactionProcessor.cs
+++ b/FactoryMethodDesignPattern/Manager/Processors/DebitTransactionProcessor.cs
@@ -2,34 +2,15 @@
 {
     using Base;
     using Domain;
-    using Domain.Base;
     using Interfaces;
 
     public class DebitTransactionProcessor : ProcessorBase<DebitTransaction>, ITransactionProcessor
     {
-        public TransactionInfo Authorize(TransactionBase transaction)
-        {
-            var debitTransaction = ValidateTransactionType(transaction);
-
-            return ProcessAuthorization(debitTransaction);
-        }
-
-        private static TransactionInfo ProcessAuthorization(DebitTransaction debitTransaction)
-        {
-            debitTransaction.SetStatusInProgress();
-
-            BusinessSimulation(ref debitTransaction);
-
-            return new TransactionInfo(debitTransaction.TransactionKey,
-                debitTransaction.CreateDate, debitTransaction.Amount,
-                debitTransaction.TransactionStatusType);
-        }
-
         /// <summary>
         /// Código de simulação de autorização, apenas para fins didádicos
         /// </summary>
         /// <param name="debitTransaction">transação de débito</param>
-        private static void BusinessSimulation(ref DebitTransaction debitTransaction)
+        protected override void BusinessSimulation(ref DebitTransaction debitTransaction)
         {
             // Autoriza se o valor estiver entre 1 e 5.000 reais
 

--- a/FactoryMethodDesignPattern/Manager/Processors/PaymentSlipTransactionProcessor.cs
+++ b/FactoryMethodDesignPattern/Manager/Processors/PaymentSlipTransactionProcessor.cs
@@ -9,29 +9,11 @@ namespace FactoryMethodDesignPattern.Manager.Processors
 
     public class PaymentSlipTransactionProcessor : ProcessorBase<PaymentSlipTransaction>, ITransactionProcessor
     {
-        public TransactionInfo Authorize(TransactionBase transaction)
-        {
-            var paymentSlipTransaction = ValidateTransactionType(transaction);
-
-            return ProcessAuthorization(paymentSlipTransaction);
-        }
-
-        private static TransactionInfo ProcessAuthorization(PaymentSlipTransaction paymentSlipTransaction)
-        {
-            paymentSlipTransaction.SetStatusInProgress();
-
-            BusinessSimulation(ref paymentSlipTransaction);
-
-            return new TransactionInfo(paymentSlipTransaction.TransactionKey,
-                paymentSlipTransaction.CreateDate, paymentSlipTransaction.Amount,
-                    paymentSlipTransaction.TransactionStatusType);
-        }
-
         /// <summary>
         /// Código de simulação de autorização, apenas para fins didádicos
         /// </summary>
         /// <param name="paymentSlipTransaction">transação de boleto</param>
-        private static void BusinessSimulation(ref PaymentSlipTransaction paymentSlipTransaction)
+        protected override void BusinessSimulation(ref PaymentSlipTransaction paymentSlipTransaction)
         {
             /* Autoriza se o valor estiver entre 100 e 20.000 reais e a
                     data de vencimento for maior que a data atual  */

--- a/FactoryMethodDesignPattern/Program.cs
+++ b/FactoryMethodDesignPattern/Program.cs
@@ -45,6 +45,20 @@ namespace FactoryMethodDesignPattern
                               $"{debitTransactionInfo.TransactionKey} | {debitTransactionInfo.TransactionStatusType}");
 
             #endregion
+
+            #region PaymentSlip Transaction
+
+            var paymentSlipTransactionProcessor =
+                TransactionProcessorFactory.CreateTransactionProcessor(TransactionType.PaymentSlip);
+
+            var paymentSlipTransaction = new PaymentSlipTransaction(2000, "001", "0000-0000", DateTime.Now);
+
+            var paymentSlipTransactionInfo = paymentSlipTransactionProcessor.Authorize(paymentSlipTransaction);
+
+            Console.WriteLine($"{paymentSlipTransactionInfo.Amount} | {paymentSlipTransactionInfo.CreateDate:g} | " +
+                              $"{paymentSlipTransactionInfo.TransactionKey} | {paymentSlipTransactionInfo.TransactionStatusType}");
+
+            #endregion
         }
     }
 }


### PR DESCRIPTION
Notei que o método Authorize e ProcessAuthorization estavam sendo repetidos nos 3 tipos de transação, realizei uma mudança para que eles fossem implementados na classe base e as implementações de ProcessorBase implementassem o método BusinessSimulation.